### PR TITLE
Update trait-nss-template-impl.php

### DIFF
--- a/core/traits/trait-nss-template-impl.php
+++ b/core/traits/trait-nss-template-impl.php
@@ -30,15 +30,15 @@ if ( ! trait_exists( 'NSS_Template_Impl' ) ) {
 				}
 
 				$paths = [
-					$variant ? STYLESHEETPATH . "/nss/{$dir}/{$file_name}-{$variant}.{$ext}" : false,
-					STYLESHEETPATH . "/nss/{$dir}/{$file_name}.{$ext}",
-					$variant ? TEMPLATEPATH . "/nss/{$dir}/{$file_name}-{$variant}.{$ext}" : false,
-					TEMPLATEPATH . "/nss/{$dir}/{$file_name}.{$ext}",
+					$variant ? get_stylesheet_directory() . "/nss/{$dir}/{$file_name}-{$variant}.{$ext}" : false,
+					get_stylesheet_directory() . "/nss/{$dir}/{$file_name}.{$ext}",
+					$variant ? get_template_directory() . "/nss/{$dir}/{$file_name}-{$variant}.{$ext}" : false,
+					get_template_directory() . "/nss/{$dir}/{$file_name}.{$ext}",
 					$variant ? plugin_dir_path( nss()->get_main_file() ) . "includes/templates/{$dir}/{$file_name}-{$variant}.{$ext}" : false,
 					plugin_dir_path( nss()->get_main_file() ) . "includes/templates/{$dir}/{$file_name}.{$ext}",
 				];
 
-				$paths   = apply_filters( 'nss_locate_file_paths', array_filter( $paths ) );
+				$paths   = apply_filters( 'nss_locate_file_paths', array_filter( $paths ), $filename );
 				$located = false;
 
 				foreach ( (array) $paths as $path ) {


### PR DESCRIPTION
1. TEMPLATEPATH 와 STYLESHEETPATH 값이 없는 경우가 있네요.
get_template_directory() 와 get_stylesheet_directory() 를 쓰는 게 나을 듯 합니다.
함수 안의 filter 를 쓰는 경우도 있어서요.

2. nss_locate_file_paths 필터를 호출할 때 파일명도 같이 넘겨주어야 어떤 템플릿 파일을 쓰는지 명확합니다.
안 그러면, $paths 값에서 파일명을 추출해야 합니다.