### PR TITLE
Add clipboard fallback function

### DIFF
--- a/assets/js/front.js
+++ b/assets/js/front.js
@@ -36,7 +36,7 @@
         },
         clipboard(s) {
             if (!navigator.clipboard) {
-                clipboardFallback(s);
+                this.clipboardFallback(s);
                 return;
             }
 

--- a/assets/js/front.js
+++ b/assets/js/front.js
@@ -35,6 +35,18 @@
             document.getElementsByTagName('head')[0].appendChild(script);
         },
         clipboard(s) {
+            if (!navigator.clipboard) {
+                clipboardFallback(s);
+                return;
+            }
+
+            navigator.clipboard.writeText(s.permalink).then(function() {
+                alert(opts.textCopiedToClipboard);
+            }, function(err) {
+                console.error('Clipboard API Failed: ', err);
+            });
+        },
+        clipboardFallback(s) {
             if (s.permalink && s.permalink.length) {
                 let input = document.createElement('input');
                 input.type = 'text';


### PR DESCRIPTION
기존 `execCommand` 복사 수행시 모바일 브라우저 환경에서 키보드 창이 올라오는 것을 방지하기 위해 Clipboard API[^1]를 사용하고, 지원되지 않는 브라우저일 경우 기존 함수를 수행 할 수 있도록 폴백 함수로 변경[^2]하였습니다.

[^1]: [Clipboard API - Web API | MDN](https://developer.mozilla.org/ko/docs/Web/API/Clipboard_API)
[^2]: [How do I copy to the clipboard in JavaScript? - Stack Overflow](https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript/30810322#30810322)